### PR TITLE
Add .NET Standard 2.0 target

### DIFF
--- a/FuzzySharp/FuzzySharp.csproj
+++ b/FuzzySharp/FuzzySharp.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net45;net46;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Jacob Bayer</Authors>
     <Description>Fuzzy matcher based on FuzzyWuzzy algorithm from SeatGeek</Description>
     <PackageTags>Fuzzy String Matching FuzzyWuzzy FuzzySharp</PackageTags>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Company />
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageReleaseNotes>Compatibility with .net45 and .net46</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/FuzzySharp/FuzzySharp.csproj
+++ b/FuzzySharp/FuzzySharp.csproj
@@ -11,11 +11,4 @@
     <Version>1.0.2</Version>
     <PackageReleaseNotes>Compatibility with .net45 and .net46</PackageReleaseNotes>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Reference Include="System">
-      <HintPath>System</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Targeting .NET Standard 2.0 is the [recommended way of supporting multiple framework implementations](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#multi-targeting). 

Even though the guidelines say otherwise though, the other targets were left untouched for compatibility. 

(why .NET Standard 2.0 too? so .NET Standard libs can reference it)