### PR TITLE
when splitting strings using Regex(/s+), any leading or trailing spac…

### DIFF
--- a/FuzzySharp.Test/EvaluationTests/EvaluationTests.cs
+++ b/FuzzySharp.Test/EvaluationTests/EvaluationTests.cs
@@ -68,5 +68,19 @@ namespace FuzzySharp.Test.EvaluationTests
             var partialTokenAbbreviation = ScorerCache.Get<PartialTokenAbbreviationScorer>();
             var weighted = ScorerCache.Get<WeightedRatioScorer>();
         }
+
+        [TestMethod]
+        public void TokenInitialismScorer_WhenGivenStringWithTrailingSpaces_DoesNotBreak()
+        {
+            // arrange
+            var longer = "lusiki plaza share block ";
+            var shorter = "jmft";
+
+            // act
+            var ratio = Fuzz.TokenInitialismRatio(shorter, longer);
+
+            // assert
+            Assert.IsTrue(ratio >= 0);
+        }
     }
 }

--- a/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenDifference/TokenDifferenceScorerBase.cs
+++ b/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenDifference/TokenDifferenceScorerBase.cs
@@ -14,8 +14,8 @@ namespace FuzzySharp.SimilarityRatio.Scorer.StrategySensitive
 
         public int Score(string input1, string input2)
         {
-            var tokens1 = Regex.Split(input1, @"\s+").OrderBy(s => s).ToArray();
-            var tokens2 = Regex.Split(input2, @"\s+").OrderBy(s => s).ToArray();
+            var tokens1 = Regex.Split(input1, @"\s+").Where(s => s.Any()).OrderBy(s => s).ToArray();
+            var tokens2 = Regex.Split(input2, @"\s+").Where(s => s.Any()).OrderBy(s => s).ToArray();
 
             return Score(tokens1, tokens2);
         }

--- a/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenInitialism/TokenInitialismScorerBase.cs
+++ b/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenInitialism/TokenInitialismScorerBase.cs
@@ -26,7 +26,7 @@ namespace FuzzySharp.SimilarityRatio.Scorer.StrategySensitive
             // if longer isn't at least 3 times longer than the other, then it's probably not an initialism
             if (lenRatio < 3) return 0;
 
-            var initials = Regex.Split(longer, @"\s+").Select(s => s[0]);
+            var initials = Regex.Split(longer, @"\s+").Where(s => s.Any()).Select(s => s[0]);
 
             return Scorer(string.Join("", initials), shorter);
         }

--- a/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenSet/TokenSetScorerBase.cs
+++ b/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenSet/TokenSetScorerBase.cs
@@ -9,8 +9,8 @@ namespace FuzzySharp.SimilarityRatio.Scorer.StrategySensitive
     {
         public override int Score(string input1, string input2)
         {
-            var tokens1 = new HashSet<string>(Regex.Split(input1, @"\s+"));
-            var tokens2 = new HashSet<string>(Regex.Split(input2, @"\s+"));
+            var tokens1 = new HashSet<string>(Regex.Split(input1, @"\s+").Where(s => s.Any()));
+            var tokens2 = new HashSet<string>(Regex.Split(input2, @"\s+").Where(s => s.Any()));
 
             var sortedIntersection = String.Join(" ", tokens1.Intersect(tokens2).OrderBy(s => s)).Trim();
             var sortedDiff1To2     = (sortedIntersection + " " + String.Join(" ", tokens1.Except(tokens2).OrderBy(s => s))).Trim();

--- a/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenSort/TokenSortAlgorithm.cs
+++ b/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenSort/TokenSortAlgorithm.cs
@@ -8,8 +8,8 @@ namespace FuzzySharp.SimilarityRatio.Scorer.StrategySensitive
     {
         public override int Score(string input1, string input2)
         {
-            var sorted1 = String.Join(" ", Regex.Split(input1, @"\s+").OrderBy(s => s)).Trim();
-            var sorted2 = String.Join(" ", Regex.Split(input2, @"\s+").OrderBy(s => s)).Trim();
+            var sorted1 = String.Join(" ", Regex.Split(input1, @"\s+").Where(s => s.Any()).OrderBy(s => s)).Trim();
+            var sorted2 = String.Join(" ", Regex.Split(input2, @"\s+").Where(s => s.Any()).OrderBy(s => s)).Trim();
 
             return Scorer(sorted1, sorted2);
         }


### PR DESCRIPTION
…es would cause an empty entry in the token array. Removing empty entries prevents the initialism from failing to access the first char of each token