### PR TITLE
TokenAbbreviationScorerBase doesn't handle empty strings

### DIFF
--- a/FuzzySharp.Test/FuzzyTests/RegressionTests.cs
+++ b/FuzzySharp.Test/FuzzyTests/RegressionTests.cs
@@ -1,0 +1,76 @@
+﻿
+using FuzzySharp.SimilarityRatio;
+using FuzzySharp.SimilarityRatio.Scorer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace FuzzySharp.Test.FuzzyTests
+{
+    [TestClass]
+    public class RegressionTests
+    {
+
+
+        /// <summary>
+        /// Test to ensure that all IRatioScorer implementations handle scoring empty strings & whitespace strings
+        /// </summary>
+        [TestMethod]
+        public void TestScoringEmptyString()
+        {
+
+            var scorerType = typeof(IRatioScorer);
+            var scorerTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(s => s.GetTypes()).Where(p => scorerType.IsAssignableFrom(p) && p.IsClass && !p.IsAbstract);
+        
+
+            MethodInfo getScorerCacheMethodInfo = typeof(ScorerCache).GetMethod("Get");
+
+            string nullString = null;  //Null doesnt seem to be handled by any scorer
+            string emptyString = "";
+            string whitespaceString = " ";
+
+            string[] nullOrWhitespaceStrings = { emptyString, whitespaceString };
+
+            foreach (Type t in scorerTypes)
+            {
+                System.Diagnostics.Debug.WriteLine($"Testing {t.Name}");
+                MethodInfo m = getScorerCacheMethodInfo.MakeGenericMethod(t);
+                IRatioScorer scorer = m.Invoke(this, new object[] { }) as IRatioScorer;
+
+                foreach(string s in nullOrWhitespaceStrings)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Testing string '{s}'");
+                    try
+                    {
+                        scorer.Score(s, "TEST");
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        Assert.Fail($"{t.Name}.score failed with empty string as first parameter");
+                    }
+                    try
+                    {
+                        scorer.Score("TEST", s);
+                    } catch (InvalidOperationException e)
+                    {
+                        Assert.Fail($"{t.Name}.score failed with empty string as second parameter");
+                    }
+                    try
+                    {
+                        scorer.Score(s, s);
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        Assert.Fail($"{t.Name}.score failed with empty string as both parameters");
+                    }
+
+                }
+
+
+            }
+
+        }
+        
+    }
+}

--- a/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenAbbreviation/TokenAbbreviationScorerBase.cs
+++ b/FuzzySharp/SimilarityRatio/Scorer/StrategySensitive/TokenAbbreviation/TokenAbbreviationScorerBase.cs
@@ -70,8 +70,8 @@ namespace FuzzySharp.SimilarityRatio.Scorer.StrategySensitive
                 }
                 allScores.Add((int) (sum / fewerTokens.Length));
             }
-
-            return allScores.Max();
+            
+            return allScores.Count==0?0:allScores.Max();
         }
 
         /// <summary>


### PR DESCRIPTION
These tests check that every implementation of IRatioScorer returns a score when passed an empty string ("") or a whitespace string (" ") as either one or both of the arguments.

TokenAbbreviationScorerBase classes are failing these tests but other scorers do not, so it would seem logical that TokenAbbreviationScorerBase classes should not throw an exception.

My fix just returns a 0 score instead of throwing an exception.  It might be better to pre-check for empty strings and shortcut attempting to calculate the score, but I didn't try to understand the logic and didn't want to mess something up.