### PR TITLE
add overloads for selecting <T> by string query

### DIFF
--- a/FuzzySharp/Extractor/ResultExtractor.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.cs
@@ -8,13 +8,12 @@ namespace FuzzySharp.Extractor
 {
     public static class ResultExtractor
     {
-        public static IEnumerable<ExtractedResult<T>> ExtractWithoutOrder<T>(T query, IEnumerable<T> choices, Func<T,string> processor, IRatioScorer scorer, int cutoff = 0)
+        public static IEnumerable<ExtractedResult<T>> ExtractWithoutOrder<T>(string query, IEnumerable<T> choices, Func<T,string> processor, IRatioScorer scorer, int cutoff = 0)
         {
             int index = 0;
-            var processedQuery = processor(query);
             foreach (var choice in choices)
             {
-                int score = scorer.Score(processedQuery, processor(choice));
+                int score = scorer.Score(query, processor(choice));
                 if (score >= cutoff)
                 {
                     yield return new ExtractedResult<T>(choice, score, index);
@@ -23,7 +22,17 @@ namespace FuzzySharp.Extractor
             }
         }
 
+
+        public static IEnumerable<ExtractedResult<T>> ExtractWithoutOrder<T>(T query, IEnumerable<T> choices, Func<T,string> processor, IRatioScorer scorer, int cutoff = 0)
+        {
+            return ExtractWithoutOrder(processor(query), choices, processor, scorer, cutoff);
+        }
+
         public static ExtractedResult<T> ExtractOne<T>(T query, IEnumerable<T> choices, Func<T, string> processor, IRatioScorer calculator, int cutoff = 0)
+        {
+            return ExtractWithoutOrder(query, choices, processor, calculator, cutoff).Max();
+        }
+        public static ExtractedResult<T> ExtractOne<T>(string query, IEnumerable<T> choices, Func<T, string> processor, IRatioScorer calculator, int cutoff = 0)
         {
             return ExtractWithoutOrder(query, choices, processor, calculator, cutoff).Max();
         }
@@ -32,8 +41,18 @@ namespace FuzzySharp.Extractor
         {
             return ExtractWithoutOrder(query, choices, processor, calculator, cutoff).OrderByDescending(r => r.Score);
         }
+        
+        public static IEnumerable<ExtractedResult<T>> ExtractSorted<T>(string query, IEnumerable<T> choices, Func<T, string> processor, IRatioScorer calculator, int cutoff = 0)
+        {
+            return ExtractWithoutOrder(query, choices, processor, calculator, cutoff).OrderByDescending(r => r.Score);
+        }
 
         public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(T query, IEnumerable<T> choices, Func<T, string> processor, IRatioScorer calculator, int limit, int cutoff = 0)
+        {
+            return ExtractWithoutOrder(query, choices, processor, calculator, cutoff).MaxN(limit).Reverse();
+        }        
+        
+        public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(string query, IEnumerable<T> choices, Func<T, string> processor, IRatioScorer calculator, int limit, int cutoff = 0)
         {
             return ExtractWithoutOrder(query, choices, processor, calculator, cutoff).MaxN(limit).Reverse();
         }

--- a/FuzzySharp/Process.cs
+++ b/FuzzySharp/Process.cs
@@ -47,6 +47,27 @@ namespace FuzzySharp
         /// <param name="cutoff"></param>
         /// <returns></returns>
         public static IEnumerable<ExtractedResult<T>> ExtractAll<T>(
+            string query, 
+            IEnumerable<T> choices,
+            Func<T, string> processor,
+            IRatioScorer scorer = null,
+            int cutoff = 0)
+        {
+            if (scorer == null) scorer = s_defaultScorer;
+            return ResultExtractor.ExtractWithoutOrder(query, choices, processor, scorer, cutoff);
+        }
+
+        /// <summary>
+        /// Creates a list of ExtractedResult which contain all the choices with
+        /// their corresponding score where higher is more similar
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="choices"></param>
+        /// <param name="processor"></param>
+        /// <param name="scorer"></param>
+        /// <param name="cutoff"></param>
+        /// <returns></returns>
+        public static IEnumerable<ExtractedResult<T>> ExtractAll<T>(
             T query, 
             IEnumerable<T> choices,
             Func<T, string> processor,
@@ -79,6 +100,30 @@ namespace FuzzySharp
             int cutoff = 0)
         {
             if (processor == null) processor = s_defaultStringProcessor;
+            if (scorer == null) scorer = s_defaultScorer;
+            return ResultExtractor.ExtractTop(query, choices, processor, scorer, limit, cutoff);
+        }
+
+
+        /// <summary>
+        /// Creates a sorted list of ExtractedResult  which contain the
+        /// top limit most similar choices
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="choices"></param>
+        /// <param name="processor"></param>
+        /// <param name="scorer"></param>
+        /// <param name="limit"></param>
+        /// <param name="cutoff"></param>
+        /// <returns></returns>
+        public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(
+            string query, 
+            IEnumerable<T> choices,
+            Func<T, string> processor,
+            IRatioScorer scorer = null,
+            int limit = 5, 
+            int cutoff = 0)
+        {
             if (scorer == null) scorer = s_defaultScorer;
             return ResultExtractor.ExtractTop(query, choices, processor, scorer, limit, cutoff);
         }
@@ -140,6 +185,26 @@ namespace FuzzySharp
         /// <param name="cutoff"></param>
         /// <returns></returns>
         public static IEnumerable<ExtractedResult<T>> ExtractSorted<T>(
+            string query,
+            IEnumerable<T> choices,
+            Func<T, string> processor,
+            IRatioScorer scorer = null,
+            int cutoff = 0)
+        {
+            if (scorer == null) scorer = s_defaultScorer;
+            return ResultExtractor.ExtractSorted(query, choices, processor, scorer, cutoff);
+        }
+
+        /// <summary>
+        /// Creates a sorted list of ExtractedResult with the closest matches first
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="choices"></param>
+        /// <param name="processor"></param>
+        /// <param name="scorer"></param>
+        /// <param name="cutoff"></param>
+        /// <returns></returns>
+        public static IEnumerable<ExtractedResult<T>> ExtractSorted<T>(
             T query,
             IEnumerable<T> choices,
             Func<T, string> processor,
@@ -169,6 +234,26 @@ namespace FuzzySharp
             int cutoff = 0)
         {
             if (processor == null) processor = s_defaultStringProcessor;
+            if (scorer == null) scorer       = s_defaultScorer;
+            return ResultExtractor.ExtractOne(query, choices, processor, scorer, cutoff);
+        }
+
+        /// <summary>
+        /// Find the single best match above a score in a list of choices.
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="choices"></param>
+        /// <param name="processor"></param>
+        /// <param name="scorer"></param>
+        /// <param name="cutoff"></param>
+        /// <returns></returns>
+        public static ExtractedResult<T> ExtractOne<T>(
+            string query,
+            IEnumerable<T> choices,
+            Func<T, string> processor,
+            IRatioScorer scorer = null,
+            int cutoff = 0)
+        {
             if (scorer == null) scorer       = s_defaultScorer;
             return ResultExtractor.ExtractOne(query, choices, processor, scorer, cutoff);
         }


### PR DESCRIPTION
Add overloads for `Process.Extract..()` methods to allow choosing generic `T` by a `string` key.

Good for when you don't want the query to also be an object of type `T`.

Simplifies..

```csharp
var bestMatchName = Process.ExtractOne(name, candidates.Select(pr => pr.Name));

var bestMatch = potentialRacesForTrack.First(pr => pr.Name == bestMatchName.Value);
```

to

```csharp
var bestMatch = Process.ExtractOne(name, candidates.Select(pr => pr.Name));
```